### PR TITLE
Reduce per-frame allocations and fix O(n×s) lookups

### DIFF
--- a/model.go
+++ b/model.go
@@ -563,8 +563,10 @@ func (m *model) updateDirSizes(sizes map[string]int64) {
 		return
 	}
 
-	// Re-sort and reapply filter
-	sortEntries(bt.allEntries, m.sortBy)
+	// Re-sort only when sorting by size (other sort keys are unaffected by size changes)
+	if m.sortBy == sortSizeDesc {
+		sortEntries(bt.allEntries, m.sortBy)
+	}
 	m.applyFilterForTab(tabBrowse)
 
 	// Restore cursor to the same entry
@@ -582,42 +584,6 @@ func (m *model) updateDirSizes(sizes map[string]int64) {
 	ce := m.cache[m.path]
 	ce.browseEntries = bt.allEntries
 	m.cache[m.path] = ce
-}
-
-// updateEntrySize updates a directory entry's size and re-sorts with stable cursor.
-func (m *model) updateEntrySize(path string, size int64) {
-	bt := &m.tabs[tabBrowse]
-	// Remember what the cursor points to
-	var cursorPath string
-	if bt.cursor < len(bt.entries) {
-		cursorPath = bt.entries[bt.cursor].Path
-	}
-
-	// Update the size in allEntries
-	for i := range bt.allEntries {
-		if bt.allEntries[i].Path == path {
-			bt.allEntries[i].Size = size
-			bt.allEntries[i].Sized = true
-			break
-		}
-	}
-
-	// Re-sort allEntries using current sort mode
-	sortEntries(bt.allEntries, m.sortBy)
-
-	// Reapply filter to rebuild entries from sorted allEntries
-	m.applyFilterForTab(tabBrowse)
-
-	// Restore cursor to the same entry
-	if cursorPath != "" {
-		for i, e := range bt.entries {
-			if e.Path == cursorPath {
-				bt.cursor = i
-				break
-			}
-		}
-	}
-	m.clampOffset()
 }
 
 // removeDeleted removes deleted paths from entries and selection across all tabs, fixes cursor.

--- a/model_test.go
+++ b/model_test.go
@@ -597,33 +597,6 @@ func TestEntryDisplayName_EmptyPath(t *testing.T) {
 	}
 }
 
-func TestUpdateEntrySize(t *testing.T) {
-	m := newTestModel()
-	tab := m.tab()
-	tab.allEntries = []Entry{
-		{Name: "..", Path: "/tmp", IsDir: true, IsParent: true},
-		{Name: "dir1", Path: "/tmp/test/dir1", IsDir: true, Sized: false, Size: 0},
-		{Name: "dir2", Path: "/tmp/test/dir2", IsDir: true, Sized: true, Size: 100},
-	}
-	tab.entries = append([]Entry{}, tab.allEntries...)
-	tab.cursor = 2 // pointing at dir2
-
-	m.updateEntrySize("/tmp/test/dir1", 500)
-
-	var found bool
-	for _, e := range tab.allEntries {
-		if e.Path == "/tmp/test/dir1" {
-			if e.Size != 500 || !e.Sized {
-				t.Errorf("dir1: size=%d sized=%v", e.Size, e.Sized)
-			}
-			found = true
-		}
-	}
-	if !found {
-		t.Error("dir1 not found after update")
-	}
-}
-
 func TestNavigateToVirtualRoot(t *testing.T) {
 	paths := []string{"/a", "/b"}
 	m := newMultiRootModel(paths, 100, false, false)

--- a/scanner.go
+++ b/scanner.go
@@ -181,7 +181,7 @@ func quickScanDir(path string) ([]Entry, error) {
 		return nil, err
 	}
 
-	entries := make([]Entry, 0, len(dirEntries))
+	entries := make([]Entry, 0, len(dirEntries)+1)
 	for _, de := range dirEntries {
 		fullPath := filepath.Join(path, de.Name())
 		isSymlink := de.Type()&os.ModeSymlink != 0

--- a/styles.go
+++ b/styles.go
@@ -192,4 +192,21 @@ var (
 		"#908450",
 		"#7d7248",
 	}
+
+	// Pre-built gradient styles (one per scanGradient color)
+	scanGradientStyles []lipgloss.Style
+
+	// Hoisted inline styles used in View()
+	freeTextStyle       = lipgloss.NewStyle().Foreground(colorGreen).Bold(true)
+	readOnlyBadgeStyle  = lipgloss.NewStyle().Foreground(colorGreen).Bold(true)
+	permDeleteBadgeStyle = lipgloss.NewStyle().Foreground(colorRed).Bold(true)
+	separatorStyle      = lipgloss.NewStyle().Foreground(colorBorder)
+	readOnlyStatusStyle = lipgloss.NewStyle().Foreground(colorGreen)
 )
+
+func init() {
+	scanGradientStyles = make([]lipgloss.Style, len(scanGradient))
+	for i, c := range scanGradient {
+		scanGradientStyles[i] = lipgloss.NewStyle().Foreground(c)
+	}
+}

--- a/view.go
+++ b/view.go
@@ -26,8 +26,7 @@ func gradientWave(text string, phase int) string {
 			continue
 		}
 		idx := ((i + phase) % wl + wl) % wl
-		s := lipgloss.NewStyle().Foreground(scanGradient[idx])
-		b.WriteString(s.Render(string(r)))
+		b.WriteString(scanGradientStyles[idx].Render(string(r)))
 	}
 	return b.String()
 }
@@ -221,6 +220,7 @@ func (m model) View() string {
 	}
 
 	var b strings.Builder
+	b.Grow(8192)
 	contentWidth := m.width - 2
 
 	// ASCII art logo + disk free
@@ -247,7 +247,7 @@ func (m model) View() string {
 			if pad < 1 {
 				pad = 1
 			}
-			styled += strings.Repeat(" ", pad) + lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render(freeText)
+			styled += strings.Repeat(" ", pad) + freeTextStyle.Render(freeText)
 		}
 		b.WriteString(styled)
 		b.WriteString("\n")
@@ -256,9 +256,9 @@ func (m model) View() string {
 	// Path
 	var pathPrefix string
 	if m.readOnly {
-		pathPrefix = lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render("READ-ONLY") + " "
+		pathPrefix = readOnlyBadgeStyle.Render("READ-ONLY") + " "
 	} else if m.deleteType == deletePermanent {
-		pathPrefix = lipgloss.NewStyle().Foreground(colorRed).Bold(true).Render("⚠ PERMANENT DELETE") + " "
+		pathPrefix = permDeleteBadgeStyle.Render("⚠ PERMANENT DELETE") + " "
 	}
 	pathLine := pathStyle.Width(contentWidth).Render(" " + pathPrefix + m.path)
 	b.WriteString(pathLine)
@@ -268,8 +268,9 @@ func (m model) View() string {
 	b.WriteString(m.renderTabBar(contentWidth))
 	b.WriteString("\n")
 
-	// Separator
-	b.WriteString(lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", contentWidth)))
+	// Separator (computed once, reused)
+	separator := separatorStyle.Render(strings.Repeat("─", contentWidth))
+	b.WriteString(separator)
 	b.WriteString("\n")
 
 	// Error
@@ -541,20 +542,21 @@ func (m model) View() string {
 	}
 
 	// Separator
-	b.WriteString(lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", contentWidth)))
+	b.WriteString(separator)
 	b.WriteString("\n")
 
 	// Confirm dialog / filter input / help line
 	if m.mode == modeConfirm {
 		totalSize := int64(0)
 		count := 0
+		sizeMap := make(map[string]int64, len(t.entries))
+		for _, e := range t.entries {
+			sizeMap[e.Path] = e.Size
+		}
 		for p := range t.selected {
-			for _, e := range t.entries {
-				if e.Path == p {
-					totalSize += e.Size
-					count++
-					break
-				}
+			if sz, ok := sizeMap[p]; ok {
+				totalSize += sz
+				count++
 			}
 		}
 		var confirmText string
@@ -625,11 +627,14 @@ func (m model) View() string {
 		b.WriteString(scanningStyle.Width(contentWidth).Render(status))
 	} else {
 		var totalSelected int64
-		for p := range t.selected {
+		if len(t.selected) > 0 {
+			sizeMap := make(map[string]int64, len(t.entries))
 			for _, e := range t.entries {
-				if e.Path == p {
-					totalSelected += e.Size
-					break
+				sizeMap[e.Path] = e.Size
+			}
+			for p := range t.selected {
+				if sz, ok := sizeMap[p]; ok {
+					totalSelected += sz
 				}
 			}
 		}
@@ -648,7 +653,7 @@ func (m model) View() string {
 			status += " · PERM DELETE"
 		}
 		if m.readOnly {
-			status += " · " + lipgloss.NewStyle().Foreground(colorGreen).Render("READ-ONLY")
+			status += " · " + readOnlyStatusStyle.Render("READ-ONLY")
 		}
 		b.WriteString(statusBarStyle.Width(contentWidth).Render(status))
 	}
@@ -671,18 +676,19 @@ func (m model) viewDryRun(b *strings.Builder, contentWidth int) string {
 
 	count := 0
 	var totalSize int64
+	sizeMap := make(map[string]int64, len(t.allEntries))
+	for _, e := range t.allEntries {
+		sizeMap[e.Path] = e.Size
+	}
 	for p := range t.selected {
-		for _, e := range t.allEntries {
-			if e.Path == p {
-				if count < visibleRows {
-					line := fmt.Sprintf("  %9s  %s", formatSize(e.Size), e.Path)
-					b.WriteString(line)
-					b.WriteString("\n")
-				}
-				totalSize += e.Size
-				count++
-				break
+		if sz, ok := sizeMap[p]; ok {
+			if count < visibleRows {
+				line := fmt.Sprintf("  %9s  %s", formatSize(sz), p)
+				b.WriteString(line)
+				b.WriteString("\n")
 			}
+			totalSize += sz
+			count++
 		}
 	}
 
@@ -700,7 +706,7 @@ func (m model) viewDryRun(b *strings.Builder, contentWidth int) string {
 	}
 
 	// Separator
-	b.WriteString(lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", contentWidth)))
+	b.WriteString(separatorStyle.Render(strings.Repeat("─", contentWidth)))
 	b.WriteString("\n")
 
 	// Summary + help
@@ -788,7 +794,7 @@ func (m model) viewHelp(b *strings.Builder, contentWidth int) string {
 	}
 
 	// Separator
-	b.WriteString(lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", contentWidth)))
+	b.WriteString(separatorStyle.Render(strings.Repeat("─", contentWidth)))
 	b.WriteString("\n")
 
 	// Help line


### PR DESCRIPTION
## Summary
- Pre-build gradient styles and hoist inline `lipgloss.NewStyle()` calls to package-level vars to eliminate hot-path allocations
- Replace O(n×s) selected-size lookups with O(1) map lookups in confirm/status/dry-run views
- Skip redundant `sortEntries` during deep scan when not sorting by size; pre-grow `strings.Builder`; cache separator string
- Fix parent-prepend reallocation in `quickScanDir`; remove dead `updateEntrySize`

## Test plan
- [x] `go build ./...` — macOS
- [x] `GOOS=linux go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)