### PR TITLE
Add CACHES tab: safe application cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Switch to permanent mode with `tab` when you're sure. Confirmation dialog keeps 
 
 ![largest files](docs/largest.gif)
 
+### Clear app caches safely
+
+The CACHES tab finds known caches — dev tools (npm, go, cargo, Xcode…), browsers, messengers (Telegram, WhatsApp, Slack, Discord) and popular apps — and lets you trash or delete them. Docker is cleaned via `docker system prune -a -f` with confirmation.
+
 ### Filter by name
 
 Press `f` and type to instantly filter entries. Great for finding files by extension.
@@ -90,7 +94,7 @@ Press `f` and type to instantly filter entries. Great for finding files by exten
 | `h` | Toggle hidden files |
 | `t` | Cycle sort mode (size / name / updated / created) |
 | `tab` | Toggle trash / permanent delete |
-| `shift+tab` | Switch between Browse and Largest tabs |
+| `shift+tab` | Switch tabs (Browse / Largest / Caches / History) |
 | `space` | Quick Look preview (macOS) |
 | `?` | Help |
 | `q` / `ctrl+c` | Quit |

--- a/caches.go
+++ b/caches.go
@@ -3,12 +3,15 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // cacheKind distinguishes plain directory caches from special entries.
@@ -169,4 +172,79 @@ func sumPathsSize(paths []string) int64 {
 		})
 	}
 	return total
+}
+
+// cachesLoadedMsg is sent when the CACHES tab scan completes.
+type cachesLoadedMsg struct {
+	entries    []Entry
+	pathGroups map[string][]string
+}
+
+// cacheSizeMsg carries the computed size of one cache row.
+// ok=false means the row must be dropped (e.g. docker df failed).
+type cacheSizeMsg struct {
+	path string
+	size int64
+	ok   bool
+}
+
+// dockerPruneDoneMsg is sent after docker system prune succeeds.
+type dockerPruneDoneMsg struct {
+	reclaimed int64
+}
+
+// dockerPruneErrMsg is sent when docker system prune fails.
+type dockerPruneErrMsg struct {
+	err error
+}
+
+// loadCachesCmd scans the platform cache registry and the docker CLI.
+func loadCachesCmd() tea.Cmd {
+	return func() tea.Msg {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return cachesLoadedMsg{}
+		}
+		hits := scanCaches(platformCacheDefs(), home)
+		entries := make([]Entry, 0, len(hits)+1)
+		groups := make(map[string][]string, len(hits))
+		for _, h := range hits {
+			primary := h.Paths[0]
+			entries = append(entries, Entry{Name: h.Def.Name, Path: primary, IsDir: true})
+			groups[primary] = h.Paths
+		}
+		if dockerAvailable() {
+			entries = append(entries, Entry{Name: "Docker (system prune -a)", Path: dockerEntryPath})
+		}
+		return cachesLoadedMsg{entries: entries, pathGroups: groups}
+	}
+}
+
+// cacheSizeCmd computes the total size of one cache row in the background.
+func cacheSizeCmd(primary string, paths []string) tea.Cmd {
+	return func() tea.Msg {
+		return cacheSizeMsg{path: primary, size: sumPathsSize(paths), ok: true}
+	}
+}
+
+// dockerSizeCmd queries docker reclaimable space; on failure the row is dropped.
+func dockerSizeCmd() tea.Cmd {
+	return func() tea.Msg {
+		size, err := dockerReclaimable()
+		if err != nil {
+			return cacheSizeMsg{path: dockerEntryPath, ok: false}
+		}
+		return cacheSizeMsg{path: dockerEntryPath, size: size, ok: true}
+	}
+}
+
+// dockerPruneCmd runs docker system prune -a -f.
+func dockerPruneCmd() tea.Cmd {
+	return func() tea.Msg {
+		out, err := exec.Command("docker", "system", "prune", "-a", "-f").CombinedOutput()
+		if err != nil {
+			return dockerPruneErrMsg{err: fmt.Errorf("docker prune: %v: %s", err, bytes.TrimSpace(out))}
+		}
+		return dockerPruneDoneMsg{reclaimed: parseDockerPruneOutput(string(out))}
+	}
 }

--- a/caches.go
+++ b/caches.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cacheKind distinguishes plain directory caches from special entries.
+type cacheKind int
+
+const (
+	cacheKindDir    cacheKind = iota // directory cache, cleared by file deletion
+	cacheKindDocker                  // special entry, cleared via docker system prune
+)
+
+// dockerEntryPath is the sentinel Entry.Path for the Docker row on the CACHES tab.
+const dockerEntryPath = "docker://prune"
+
+// cacheDef describes one known application cache location.
+// Paths may contain "~" (expanded to home) and glob metacharacters
+// (expanded via filepath.Glob; single-star segments only — Glob has no **).
+type cacheDef struct {
+	Name  string
+	Paths []string
+	Kind  cacheKind
+}
+
+// cacheHit is a cacheDef whose paths (at least one) exist on disk.
+type cacheHit struct {
+	Def   cacheDef
+	Paths []string
+}
+
+// resolveCachePaths expands ~ and glob patterns, keeping only existing paths.
+func resolveCachePaths(patterns []string, home string) []string {
+	var out []string
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(p, "~") {
+			p = filepath.Join(home, p[1:])
+		}
+		if strings.ContainsAny(p, "*?[") {
+			matches, err := filepath.Glob(p)
+			if err != nil {
+				continue
+			}
+			for _, match := range matches {
+				if _, err := os.Stat(match); err == nil {
+					out = append(out, match)
+				}
+			}
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// scanCaches resolves every cacheDir def and returns those with existing paths.
+func scanCaches(defs []cacheDef, home string) []cacheHit {
+	var hits []cacheHit
+	for _, d := range defs {
+		if d.Kind != cacheKindDir {
+			continue
+		}
+		paths := resolveCachePaths(d.Paths, home)
+		if len(paths) > 0 {
+			hits = append(hits, cacheHit{Def: d, Paths: paths})
+		}
+	}
+	return hits
+}
+
+// sumPathsSize walks all paths and sums regular-file sizes. Errors are skipped.
+func sumPathsSize(paths []string) int64 {
+	var total int64
+	for _, p := range paths {
+		_ = filepath.WalkDir(p, func(_ string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.Type().IsRegular() {
+				if info, err := d.Info(); err == nil {
+					total += info.Size()
+				}
+			}
+			return nil
+		})
+	}
+	return total
+}

--- a/caches.go
+++ b/caches.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -75,6 +79,77 @@ func scanCaches(defs []cacheDef, home string) []cacheHit {
 		}
 	}
 	return hits
+}
+
+// dockerAvailable reports whether the docker CLI is on PATH.
+func dockerAvailable() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
+}
+
+// parseDockerSize parses docker-style human sizes ("1.5GB (90%)", "500MB",
+// "0B"). Docker uses decimal units. Returns 0 on any parse failure.
+func parseDockerSize(s string) int64 {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		s = s[:i] // strip trailing " (90%)"
+	}
+	i := 0
+	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.') {
+		i++
+	}
+	num, err := strconv.ParseFloat(s[:i], 64)
+	if err != nil {
+		return 0
+	}
+	mult := map[string]float64{"B": 1, "KB": 1e3, "MB": 1e6, "GB": 1e9, "TB": 1e12}
+	m, ok := mult[strings.ToUpper(s[i:])]
+	if !ok {
+		return 0
+	}
+	return int64(num * m)
+}
+
+// parseDockerDF sums the Reclaimable field over `docker system df --format
+// '{{json .}}'` NDJSON output. Unparseable lines are skipped.
+func parseDockerDF(out []byte) int64 {
+	var total int64
+	for _, line := range bytes.Split(out, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var row struct{ Reclaimable string }
+		if err := json.Unmarshal(line, &row); err != nil {
+			continue
+		}
+		total += parseDockerSize(row.Reclaimable)
+	}
+	return total
+}
+
+// dockerReclaimable queries docker for total reclaimable space.
+func dockerReclaimable() (int64, error) {
+	out, err := exec.Command("docker", "system", "df", "--format", "{{json .}}").Output()
+	if err != nil {
+		return 0, err
+	}
+	return parseDockerDF(out), nil
+}
+
+// parseDockerPruneOutput extracts the freed size from `docker system prune`
+// output ("Total reclaimed space: 4.2GB"). Returns 0 if absent.
+func parseDockerPruneOutput(out string) int64 {
+	const marker = "Total reclaimed space:"
+	i := strings.LastIndex(out, marker)
+	if i < 0 {
+		return 0
+	}
+	rest := out[i+len(marker):]
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		rest = rest[:nl]
+	}
+	return parseDockerSize(rest)
 }
 
 // sumPathsSize walks all paths and sums regular-file sizes. Errors are skipped.

--- a/caches_darwin.go
+++ b/caches_darwin.go
@@ -1,0 +1,64 @@
+//go:build darwin
+
+package main
+
+// platformCacheDefs returns the curated cache registry for macOS.
+// Only cache subdirectories — never profiles, user data or message stores.
+func platformCacheDefs() []cacheDef {
+	return []cacheDef{
+		// Dev tools
+		{Name: "npm cache", Paths: []string{"~/.npm/_cacache"}},
+		{Name: "yarn cache", Paths: []string{"~/Library/Caches/Yarn"}},
+		{Name: "pnpm store", Paths: []string{"~/Library/pnpm/store", "~/.pnpm-store"}},
+		{Name: "pip cache", Paths: []string{"~/Library/Caches/pip"}},
+		{Name: "Go build cache", Paths: []string{"~/Library/Caches/go-build"}},
+		{Name: "Cargo registry cache", Paths: []string{"~/.cargo/registry/cache"}},
+		{Name: "Gradle caches", Paths: []string{"~/.gradle/caches"}},
+		{Name: "Homebrew cache", Paths: []string{"~/Library/Caches/Homebrew"}},
+		{Name: "Composer cache", Paths: []string{"~/Library/Caches/composer"}},
+		{Name: "Hugging Face hub", Paths: []string{"~/.cache/huggingface"}},
+		{Name: "CocoaPods cache", Paths: []string{"~/Library/Caches/CocoaPods"}},
+		{Name: "Xcode DerivedData", Paths: []string{"~/Library/Developer/Xcode/DerivedData"}},
+		{Name: "JetBrains caches", Paths: []string{"~/Library/Caches/JetBrains"}},
+		{Name: "VS Code cache", Paths: []string{
+			"~/Library/Application Support/Code/Cache",
+			"~/Library/Application Support/Code/CachedData",
+		}},
+		// Browsers (cache dirs only)
+		{Name: "Chrome cache", Paths: []string{"~/Library/Caches/Google/Chrome"}},
+		{Name: "Chromium cache", Paths: []string{"~/Library/Caches/Chromium"}},
+		{Name: "Firefox cache", Paths: []string{"~/Library/Caches/Firefox/Profiles/*"}},
+		{Name: "Safari cache", Paths: []string{"~/Library/Caches/com.apple.Safari"}},
+		{Name: "Edge cache", Paths: []string{"~/Library/Caches/Microsoft Edge"}},
+		{Name: "Brave cache", Paths: []string{"~/Library/Caches/BraveSoftware"}},
+		{Name: "Opera cache", Paths: []string{"~/Library/Caches/com.operasoftware.Opera"}},
+		{Name: "Arc cache", Paths: []string{"~/Library/Caches/Arc"}},
+		{Name: "Yandex Browser cache", Paths: []string{"~/Library/Caches/Yandex/YandexBrowser"}},
+		// Messengers (media/web caches only)
+		{Name: "Telegram cache", Paths: []string{
+			"~/Library/Group Containers/*.keepcoder.Telegram/appstore/account-*/postbox/media",
+			"~/Library/Caches/ru.keepcoder.Telegram",
+			"~/Library/Application Support/Telegram Desktop/tdata/user_data*/media_cache",
+		}},
+		{Name: "WhatsApp cache", Paths: []string{
+			"~/Library/Caches/net.whatsapp.WhatsApp",
+			"~/Library/Group Containers/*.net.whatsapp.WhatsApp*/Library/Caches",
+		}},
+		{Name: "Slack cache", Paths: []string{
+			"~/Library/Application Support/Slack/Cache",
+			"~/Library/Application Support/Slack/Service Worker/CacheStorage",
+			"~/Library/Caches/com.tinyspeck.slackmacgap",
+		}},
+		{Name: "Discord cache", Paths: []string{
+			"~/Library/Application Support/discord/Cache",
+			"~/Library/Application Support/discord/Code Cache",
+		}},
+		// Popular apps
+		{Name: "Spotify cache", Paths: []string{"~/Library/Caches/com.spotify.client"}},
+		{Name: "Microsoft Teams cache", Paths: []string{
+			"~/Library/Caches/com.microsoft.teams2",
+			"~/Library/Caches/com.microsoft.teams",
+		}},
+		{Name: "Zoom cache", Paths: []string{"~/Library/Caches/us.zoom.xos"}},
+	}
+}

--- a/caches_linux.go
+++ b/caches_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package main
+
+// platformCacheDefs returns the curated cache registry for Linux.
+// Only cache subdirectories — never profiles, user data or message stores.
+// WhatsApp has no official Linux client, so it has no entry here.
+func platformCacheDefs() []cacheDef {
+	return []cacheDef{
+		// Dev tools
+		{Name: "npm cache", Paths: []string{"~/.npm/_cacache"}},
+		{Name: "yarn cache", Paths: []string{"~/.cache/yarn"}},
+		{Name: "pnpm store", Paths: []string{"~/.local/share/pnpm/store", "~/.pnpm-store"}},
+		{Name: "pip cache", Paths: []string{"~/.cache/pip"}},
+		{Name: "Go build cache", Paths: []string{"~/.cache/go-build"}},
+		{Name: "Cargo registry cache", Paths: []string{"~/.cargo/registry/cache"}},
+		{Name: "Gradle caches", Paths: []string{"~/.gradle/caches"}},
+		{Name: "Homebrew cache", Paths: []string{"~/.cache/Homebrew"}},
+		{Name: "Composer cache", Paths: []string{"~/.cache/composer"}},
+		{Name: "Hugging Face hub", Paths: []string{"~/.cache/huggingface"}},
+		{Name: "JetBrains caches", Paths: []string{"~/.cache/JetBrains"}},
+		{Name: "VS Code cache", Paths: []string{"~/.config/Code/Cache", "~/.config/Code/CachedData"}},
+		// Browsers (cache dirs only)
+		{Name: "Chrome cache", Paths: []string{"~/.cache/google-chrome"}},
+		{Name: "Chromium cache", Paths: []string{"~/.cache/chromium"}},
+		{Name: "Firefox cache", Paths: []string{"~/.cache/mozilla/firefox/*"}},
+		{Name: "Edge cache", Paths: []string{"~/.cache/microsoft-edge"}},
+		{Name: "Brave cache", Paths: []string{"~/.cache/BraveSoftware"}},
+		{Name: "Opera cache", Paths: []string{"~/.cache/opera"}},
+		{Name: "Yandex Browser cache", Paths: []string{"~/.cache/yandex-browser"}},
+		// Messengers (media/web caches only)
+		{Name: "Telegram cache", Paths: []string{
+			"~/.local/share/TelegramDesktop/tdata/user_data*/media_cache",
+		}},
+		{Name: "Slack cache", Paths: []string{
+			"~/.config/Slack/Cache",
+			"~/.config/Slack/Service Worker/CacheStorage",
+		}},
+		{Name: "Discord cache", Paths: []string{
+			"~/.config/discord/Cache",
+			"~/.config/discord/Code Cache",
+		}},
+		// Popular apps
+		{Name: "Spotify cache", Paths: []string{"~/.cache/spotify"}},
+		{Name: "Zoom cache", Paths: []string{"~/.cache/zoom"}},
+	}
+}

--- a/caches_test.go
+++ b/caches_test.go
@@ -107,6 +107,54 @@ func TestPlatformCacheDefs(t *testing.T) {
 	}
 }
 
+func TestParseDockerSize(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int64
+	}{
+		{"0B", 0},
+		{"500B", 500},
+		{"1.5kB", 1500},
+		{"500MB", 500_000_000},
+		{"1.5GB (90%)", 1_500_000_000},
+		{"2TB", 2_000_000_000_000},
+		{"  1.234GB  ", 1_234_000_000},
+		{"garbage", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := parseDockerSize(tt.in); got != tt.want {
+			t.Errorf("parseDockerSize(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseDockerDF(t *testing.T) {
+	out := []byte(`{"Type":"Images","Reclaimable":"1.5GB (90%)"}
+{"Type":"Containers","Reclaimable":"0B"}
+{"Type":"Local Volumes","Reclaimable":"500MB (100%)"}
+{"Type":"Build Cache","Reclaimable":"2GB"}
+not json line
+`)
+	want := int64(1_500_000_000 + 0 + 500_000_000 + 2_000_000_000)
+	if got := parseDockerDF(out); got != want {
+		t.Errorf("parseDockerDF = %d, want %d", got, want)
+	}
+	if got := parseDockerDF(nil); got != 0 {
+		t.Errorf("parseDockerDF(nil) = %d, want 0", got)
+	}
+}
+
+func TestParseDockerPruneOutput(t *testing.T) {
+	out := "Deleted Containers:\nabc123\n\nDeleted Images:\ndef456\n\nTotal reclaimed space: 4.2GB\n"
+	if got := parseDockerPruneOutput(out); got != 4_200_000_000 {
+		t.Errorf("parseDockerPruneOutput = %d, want 4200000000", got)
+	}
+	if got := parseDockerPruneOutput("no totals here"); got != 0 {
+		t.Errorf("no-total case = %d, want 0", got)
+	}
+}
+
 func mustMkdir(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(path, 0o755); err != nil {

--- a/caches_test.go
+++ b/caches_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveCachePaths(t *testing.T) {
+	home := t.TempDir()
+	// Existing plain dir
+	mustMkdir(t, filepath.Join(home, ".npm", "_cacache"))
+	// Glob targets: two profile dirs with a cache2 subdir each
+	mustMkdir(t, filepath.Join(home, "profiles", "abc.default", "cache2"))
+	mustMkdir(t, filepath.Join(home, "profiles", "xyz.dev", "cache2"))
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     int
+	}{
+		{"plain existing", []string{"~/.npm/_cacache"}, 1},
+		{"plain missing", []string{"~/.cache/nonexistent"}, 0},
+		{"glob matches two", []string{"~/profiles/*/cache2"}, 2},
+		{"glob no match", []string{"~/profiles/*/nope"}, 0},
+		{"mixed", []string{"~/.npm/_cacache", "~/profiles/*/cache2", "~/missing"}, 3},
+		{"empty pattern skipped", []string{""}, 0},
+	}
+	for _, tt := range tests {
+		got := resolveCachePaths(tt.patterns, home)
+		if len(got) != tt.want {
+			t.Errorf("%s: got %d paths %v, want %d", tt.name, len(got), got, tt.want)
+		}
+		for _, p := range got {
+			if !filepath.IsAbs(p) {
+				t.Errorf("%s: path %q is not absolute", tt.name, p)
+			}
+		}
+	}
+}
+
+func TestScanCaches(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, "a"))
+	mustMkdir(t, filepath.Join(home, "b"))
+
+	defs := []cacheDef{
+		{Name: "both exist", Paths: []string{"~/a", "~/b"}},
+		{Name: "one exists", Paths: []string{"~/a", "~/missing"}},
+		{Name: "none exist", Paths: []string{"~/missing"}},
+		{Name: "docker skipped", Paths: nil, Kind: cacheKindDocker},
+	}
+	hits := scanCaches(defs, home)
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits, want 2: %+v", len(hits), hits)
+	}
+	if hits[0].Def.Name != "both exist" || len(hits[0].Paths) != 2 {
+		t.Errorf("hit 0 = %+v, want 'both exist' with 2 paths", hits[0])
+	}
+	if hits[1].Def.Name != "one exists" || len(hits[1].Paths) != 1 {
+		t.Errorf("hit 1 = %+v, want 'one exists' with 1 path", hits[1])
+	}
+}
+
+func TestSumPathsSize(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir1, "f1"), 100)
+	mustMkdir(t, filepath.Join(dir1, "sub"))
+	mustWriteFile(t, filepath.Join(dir1, "sub", "f2"), 50)
+	mustWriteFile(t, filepath.Join(dir2, "f3"), 7)
+
+	if got := sumPathsSize([]string{dir1, dir2}); got != 157 {
+		t.Errorf("sumPathsSize = %d, want 157", got)
+	}
+	if got := sumPathsSize([]string{filepath.Join(dir1, "nope")}); got != 0 {
+		t.Errorf("missing path: sumPathsSize = %d, want 0", got)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/caches_test.go
+++ b/caches_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -75,6 +76,34 @@ func TestSumPathsSize(t *testing.T) {
 	}
 	if got := sumPathsSize([]string{filepath.Join(dir1, "nope")}); got != 0 {
 		t.Errorf("missing path: sumPathsSize = %d, want 0", got)
+	}
+}
+
+func TestPlatformCacheDefs(t *testing.T) {
+	defs := platformCacheDefs()
+	if len(defs) == 0 {
+		t.Fatal("platformCacheDefs returned no defs")
+	}
+	seen := make(map[string]bool)
+	for _, d := range defs {
+		if d.Name == "" {
+			t.Errorf("def with empty Name: %+v", d)
+		}
+		if seen[d.Name] {
+			t.Errorf("duplicate def name %q", d.Name)
+		}
+		seen[d.Name] = true
+		if d.Kind == cacheKindDir && len(d.Paths) == 0 {
+			t.Errorf("%s: cacheKindDir def has no paths", d.Name)
+		}
+		for _, p := range d.Paths {
+			if strings.Contains(p, "**") {
+				t.Errorf("%s: pattern %q uses ** which filepath.Glob does not support", d.Name, p)
+			}
+			if p == "" {
+				t.Errorf("%s: empty path pattern", d.Name)
+			}
+		}
 	}
 }
 

--- a/caches_windows.go
+++ b/caches_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// platformCacheDefs returns the curated cache registry for Windows.
+// Only cache subdirectories — never profiles, user data or message stores.
+// Entries under an unset env var are dropped.
+func platformCacheDefs() []cacheDef {
+	local := os.Getenv("LOCALAPPDATA")
+	roam := os.Getenv("APPDATA")
+	j := filepath.Join
+
+	var defs []cacheDef
+	add := func(base, name string, rel ...string) {
+		if base == "" {
+			return
+		}
+		paths := make([]string, 0, len(rel))
+		for _, r := range rel {
+			paths = append(paths, j(base, r))
+		}
+		defs = append(defs, cacheDef{Name: name, Paths: paths})
+	}
+
+	// Dev tools
+	add(local, "npm cache", "npm-cache")
+	add(local, "pip cache", j("pip", "cache"))
+	add(local, "Go build cache", "go-build")
+	add(local, "yarn cache", j("Yarn", "Cache"))
+	add(local, "Composer cache", "Composer")
+	add(local, "JetBrains caches", "JetBrains")
+	defs = append(defs,
+		cacheDef{Name: "Cargo registry cache", Paths: []string{"~/.cargo/registry/cache"}},
+		cacheDef{Name: "Gradle caches", Paths: []string{"~/.gradle/caches"}},
+		cacheDef{Name: "pnpm store", Paths: []string{"~/.pnpm-store"}},
+		cacheDef{Name: "Hugging Face hub", Paths: []string{"~/.cache/huggingface"}},
+	)
+	add(roam, "VS Code cache", j("Code", "Cache"), j("Code", "CachedData"))
+	// Browsers (cache dirs only; * matches Default and Profile N)
+	add(local, "Chrome cache",
+		j("Google", "Chrome", "User Data", "*", "Cache"),
+		j("Google", "Chrome", "User Data", "*", "Code Cache"))
+	add(local, "Edge cache",
+		j("Microsoft", "Edge", "User Data", "*", "Cache"),
+		j("Microsoft", "Edge", "User Data", "*", "Code Cache"))
+	add(local, "Firefox cache", j("Mozilla", "Firefox", "Profiles", "*", "cache2"))
+	add(local, "Brave cache",
+		j("BraveSoftware", "Brave-Browser", "User Data", "*", "Cache"))
+	add(local, "Opera cache", j("Opera Software", "Opera Stable", "Cache"))
+	add(local, "Yandex Browser cache",
+		j("Yandex", "YandexBrowser", "User Data", "*", "Cache"))
+	// Messengers (media/web caches only)
+	add(roam, "Telegram cache", j("Telegram Desktop", "tdata", "user_data*", "media_cache"))
+	add(local, "WhatsApp cache", j("WhatsApp", "Cache"))
+	add(roam, "Slack cache", j("Slack", "Cache"), j("Slack", "Service Worker", "CacheStorage"))
+	add(roam, "Discord cache", j("discord", "Cache"), j("discord", "Code Cache"))
+	// Popular apps
+	add(local, "Spotify cache", j("Spotify", "Storage"), j("Spotify", "Data"))
+	add(roam, "Zoom cache", j("Zoom", "data", "cache"))
+
+	return defs
+}

--- a/keys.go
+++ b/keys.go
@@ -115,7 +115,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.readOnly {
 			return m, nil
 		}
-		if t.cursor < len(t.entries) && !t.entries[t.cursor].IsParent {
+		if t.cursor < len(t.entries) && !t.entries[t.cursor].IsParent &&
+			t.entries[t.cursor].Path != dockerEntryPath {
 			p := t.entries[t.cursor].Path
 			if t.selected[p] {
 				delete(t.selected, p)
@@ -139,7 +140,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				lo, hi = hi, lo
 			}
 			for i := lo; i <= hi; i++ {
-				if !t.entries[i].IsParent {
+				if !t.entries[i].IsParent && t.entries[i].Path != dockerEntryPath {
 					t.selected[t.entries[i].Path] = true
 				}
 			}
@@ -213,7 +214,16 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Normal delete flow (browse/largest tabs)
+		// On caches tab, cursor on the Docker row triggers the prune flow.
+		// Always confirmed, even with -y: prune is not restorable.
+		if m.activeTab == tabCaches && len(t.selected) == 0 &&
+			t.cursor < len(t.entries) && t.entries[t.cursor].Path == dockerEntryPath {
+			m.mode = modeConfirm
+			m.confirmDocker = true
+			return m, nil
+		}
+
+		// Normal delete flow (browse/largest/caches tabs)
 		if len(t.selected) == 0 && t.cursor < len(t.entries) && !t.entries[t.cursor].IsParent {
 			t.selected[t.entries[t.cursor].Path] = true
 		}
@@ -326,6 +336,13 @@ func (m model) buildDeleteCmd(t *tabState) tea.Cmd {
 		entryMap[e.Path] = e
 	}
 	for p := range t.selected {
+		// On the caches tab a selected row may cover several paths
+		if m.activeTab == tabCaches {
+			if group, ok := m.cachePathGroups[p]; ok {
+				paths = append(paths, group...)
+				continue
+			}
+		}
 		paths = append(paths, p)
 	}
 	useTrash := m.deleteType == deleteTrash
@@ -364,6 +381,12 @@ func (m model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y":
 		t := m.tab()
 
+		// Docker prune: the flag stays set until dockerPruneDoneMsg/ErrMsg
+		// clear it, mirroring how file deletion keeps modeConfirm until done.
+		if m.confirmDocker {
+			return m, dockerPruneCmd()
+		}
+
 		// On trash tab, confirm means purge
 		if m.activeTab == tabHistory {
 			paths := make([]string, 0, len(t.selected))
@@ -390,6 +413,7 @@ func (m model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.buildDeleteCmd(t)
 
 	case "n", "esc":
+		m.confirmDocker = false
 		m.mode = modeNormal
 	}
 

--- a/keys.go
+++ b/keys.go
@@ -42,14 +42,18 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "shift+tab":
 		hasHistory := m.trashRegistry != nil && len(m.trashRegistry.Records) > 0
-		numTabs := tabID(2)
+		numTabs := tabID(3)
 		if hasHistory {
-			numTabs = 3
+			numTabs = 4
 		}
 		m.activeTab = (m.activeTab + 1) % numTabs
 		cmd := m.resetNameScroll()
-		if m.activeTab == tabHistory {
+		switch m.activeTab {
+		case tabHistory:
 			return m, tea.Batch(cmd, m.loadTrashTab())
+		case tabCaches:
+			m.cachesNote = ""
+			return m, tea.Batch(cmd, loadCachesCmd())
 		}
 		return m, cmd
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -137,26 +137,23 @@ func TestKey_ShiftS_RangeSelect(t *testing.T) {
 	}
 }
 
-func TestKey_ShiftTab_SwitchesTab_TwoTabs(t *testing.T) {
+func TestKey_ShiftTab_SwitchesTab_NoHistory(t *testing.T) {
 	m := newKeysTestModel()
-	// Empty registry → only 2 tabs
+	// Empty registry → 3 tabs (BROWSE / LARGEST / CACHES)
+	m.trashRegistry = &TrashRegistry{}
 	m.activeTab = tabBrowse
 
-	result, _ := m.Update(keyMsg("shift+tab"))
-	rm := result.(model)
-	if rm.activeTab != tabLargest {
-		t.Errorf("activeTab = %d, want tabLargest", rm.activeTab)
-	}
-
-	// Wraps back to browse (no history tab)
-	result, _ = rm.Update(keyMsg("shift+tab"))
-	rm = result.(model)
-	if rm.activeTab != tabBrowse {
-		t.Errorf("activeTab = %d, want tabBrowse", rm.activeTab)
+	want := []tabID{tabLargest, tabCaches, tabBrowse}
+	for _, w := range want {
+		result, _ := m.Update(keyMsg("shift+tab"))
+		m = result.(model)
+		if m.activeTab != w {
+			t.Fatalf("activeTab = %d, want %d", m.activeTab, w)
+		}
 	}
 }
 
-func TestKey_ShiftTab_SwitchesTab_ThreeTabs(t *testing.T) {
+func TestKey_ShiftTab_SwitchesTab_WithHistory(t *testing.T) {
 	m := newKeysTestModel()
 	// Add a record so HISTORY tab appears
 	m.trashRegistry = &TrashRegistry{
@@ -166,22 +163,13 @@ func TestKey_ShiftTab_SwitchesTab_ThreeTabs(t *testing.T) {
 	}
 	m.activeTab = tabBrowse
 
-	result, _ := m.Update(keyMsg("shift+tab"))
-	rm := result.(model)
-	if rm.activeTab != tabLargest {
-		t.Errorf("activeTab = %d, want tabLargest", rm.activeTab)
-	}
-
-	result, _ = rm.Update(keyMsg("shift+tab"))
-	rm = result.(model)
-	if rm.activeTab != tabHistory {
-		t.Errorf("activeTab = %d, want tabHistory", rm.activeTab)
-	}
-
-	result, _ = rm.Update(keyMsg("shift+tab"))
-	rm = result.(model)
-	if rm.activeTab != tabBrowse {
-		t.Errorf("activeTab = %d, want tabBrowse", rm.activeTab)
+	want := []tabID{tabLargest, tabCaches, tabHistory, tabBrowse}
+	for _, w := range want {
+		result, _ := m.Update(keyMsg("shift+tab"))
+		m = result.(model)
+		if m.activeTab != w {
+			t.Fatalf("activeTab = %d, want %d", m.activeTab, w)
+		}
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -525,5 +527,106 @@ func TestFilterMode_FiltersEntries(t *testing.T) {
 	}
 	if !found {
 		t.Error("filter should include matching entry 'bbb'")
+	}
+}
+
+func TestDockerRowNotSelectable(t *testing.T) {
+	m := newKeysTestModel()
+	m.activeTab = tabCaches
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{{Name: "Docker (system prune -a)", Path: dockerEntryPath}}
+	ct.entries = ct.allEntries
+	ct.cursor = 0
+
+	updated, _ := m.Update(keyMsg("s"))
+	m2 := updated.(model)
+	if len(m2.tabs[tabCaches].selected) != 0 {
+		t.Error("docker row must not be selectable with s")
+	}
+}
+
+func TestDockerPruneConfirmFlow(t *testing.T) {
+	m := newKeysTestModel()
+	m.activeTab = tabCaches
+	m.skipConfirm = true // -y must be ignored for docker prune
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{{Name: "Docker (system prune -a)", Path: dockerEntryPath, Sized: true}}
+	ct.entries = ct.allEntries
+	ct.cursor = 0
+
+	updated, _ := m.Update(keyMsg("d"))
+	m2 := updated.(model)
+	if m2.mode != modeConfirm || !m2.confirmDocker {
+		t.Fatalf("mode=%v confirmDocker=%v, want confirm+docker", m2.mode, m2.confirmDocker)
+	}
+
+	// n cancels and clears the docker flag
+	updated, _ = m2.Update(keyMsg("n"))
+	m3 := updated.(model)
+	if m3.mode != modeNormal || m3.confirmDocker {
+		t.Errorf("after n: mode=%v confirmDocker=%v, want normal+false", m3.mode, m3.confirmDocker)
+	}
+
+	// y returns the prune command; the flag stays set until the prune
+	// finishes (dockerPruneDoneMsg/ErrMsg clear it). Do NOT execute cmd —
+	// it would really run docker prune.
+	updated, cmd := m2.Update(keyMsg("y"))
+	m4 := updated.(model)
+	if cmd == nil {
+		t.Fatal("y must return the docker prune command")
+	}
+	if !m4.confirmDocker || m4.mode != modeConfirm {
+		t.Errorf("after y: mode=%v confirmDocker=%v, want confirm+true until prune completes",
+			m4.mode, m4.confirmDocker)
+	}
+}
+
+func TestDockerPruneReadOnly(t *testing.T) {
+	m := newKeysTestModel()
+	m.readOnly = true
+	m.activeTab = tabCaches
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{{Name: "Docker (system prune -a)", Path: dockerEntryPath, Sized: true}}
+	ct.entries = ct.allEntries
+	ct.cursor = 0
+
+	updated, cmd := m.Update(keyMsg("d"))
+	m2 := updated.(model)
+	if m2.mode != modeNormal || m2.confirmDocker || cmd != nil {
+		t.Error("read-only mode must ignore d on the docker row")
+	}
+}
+
+func TestBuildDeleteCmd_ExpandsCacheGroups(t *testing.T) {
+	dir1 := t.TempDir()
+	sub1 := filepath.Join(dir1, "cache-a")
+	sub2 := filepath.Join(dir1, "cache-b")
+	mustMkdir(t, sub1)
+	mustMkdir(t, sub2)
+	mustWriteFile(t, filepath.Join(sub1, "f"), 10)
+	mustWriteFile(t, filepath.Join(sub2, "f"), 10)
+
+	m := newKeysTestModel()
+	m.activeTab = tabCaches
+	m.deleteType = deletePermanent
+	m.cachePathGroups = map[string][]string{sub1: {sub1, sub2}}
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{{Name: "grouped cache", Path: sub1, IsDir: true, Size: 20, Sized: true}}
+	ct.entries = ct.allEntries
+	ct.selected = map[string]bool{sub1: true}
+
+	cmd := m.buildDeleteCmd(ct)
+	msg := cmd()
+	done, ok := msg.(deleteDoneMsg)
+	if !ok {
+		t.Fatalf("got %T (%v), want deleteDoneMsg", msg, msg)
+	}
+	if len(done.deleted) != 2 {
+		t.Fatalf("deleted = %v, want both group paths", done.deleted)
+	}
+	for _, p := range []string{sub1, sub2} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("%s still exists", p)
+		}
 	}
 }

--- a/model.go
+++ b/model.go
@@ -55,7 +55,7 @@ const (
 type deleteMode int
 
 const (
-	deleteTrash     deleteMode = iota
+	deleteTrash deleteMode = iota
 	deletePermanent
 )
 
@@ -101,8 +101,9 @@ type trashLoadedMsg struct {
 type tabID int
 
 const (
-	tabBrowse  tabID = iota
+	tabBrowse tabID = iota
 	tabLargest
+	tabCaches
 	tabHistory
 )
 
@@ -133,7 +134,7 @@ type dirCacheEntry struct {
 type model struct {
 	path      string
 	activeTab tabID
-	tabs      [3]tabState
+	tabs      [4]tabState
 	mode      mode
 	width     int
 	height    int
@@ -179,6 +180,11 @@ type model struct {
 
 	// Trash registry
 	trashRegistry *TrashRegistry
+
+	// CACHES tab state
+	cachePathGroups map[string][]string // Entry.Path -> all existing paths of that cache
+	confirmDocker   bool                // confirm dialog is for docker prune
+	cachesNote      string              // status-bar note, e.g. reclaimed space after prune
 
 	// CLI flags
 	readOnly    bool
@@ -415,6 +421,38 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		tt.offset = 0
 		return m, nil
 
+	case cachesLoadedMsg:
+		ct := &m.tabs[tabCaches]
+		*ct = newTabState()
+		ct.allEntries = msg.entries
+		m.applyFilterForTab(tabCaches)
+		m.cachePathGroups = msg.pathGroups
+		cmds := make([]tea.Cmd, 0, len(msg.entries))
+		for _, e := range msg.entries {
+			if e.Path == dockerEntryPath {
+				cmds = append(cmds, dockerSizeCmd())
+			} else {
+				cmds = append(cmds, cacheSizeCmd(e.Path, msg.pathGroups[e.Path]))
+			}
+		}
+		return m, tea.Batch(cmds...)
+
+	case cacheSizeMsg:
+		m.handleCacheSize(msg)
+		return m, nil
+
+	case dockerPruneDoneMsg:
+		m.mode = modeNormal
+		m.confirmDocker = false
+		m.cachesNote = "docker: reclaimed " + formatSize(msg.reclaimed)
+		return m, dockerSizeCmd()
+
+	case dockerPruneErrMsg:
+		m.mode = modeNormal
+		m.confirmDocker = false
+		m.errMsg = msg.err.Error()
+		return m, nil
+
 	case restoreDoneMsg:
 		m.removeFromTrashTab(msg.restored)
 		if m.trashRegistry != nil {
@@ -529,8 +567,8 @@ func (m model) handleNameScrollTick(msg nameScrollTickMsg) (tea.Model, tea.Cmd) 
 		return m, nil // no scrolling needed
 	}
 
-	const startPause = 7  // ticks to pause at start (~1s)
-	const endPause = 13   // ticks to pause at end (~2s at 150ms/tick)
+	const startPause = 7 // ticks to pause at start (~1s)
+	const endPause = 13  // ticks to pause at end (~2s at 150ms/tick)
 
 	m.nameScroll++
 	total := startPause + maxOffset + endPause
@@ -929,6 +967,58 @@ func (m *model) loadTrashTab() tea.Cmd {
 			return entries[i].ModTime.After(entries[j].ModTime)
 		})
 		return trashLoadedMsg{entries: entries}
+	}
+}
+
+// handleCacheSize applies a cacheSizeMsg to the CACHES tab: sets the row size
+// (or drops the row when ok=false), re-sorts by size and keeps the cursor on
+// the same entry.
+func (m *model) handleCacheSize(msg cacheSizeMsg) {
+	ct := &m.tabs[tabCaches]
+
+	var cursorPath string
+	if ct.cursor < len(ct.entries) {
+		cursorPath = ct.entries[ct.cursor].Path
+	}
+
+	if msg.ok {
+		for i := range ct.allEntries {
+			if ct.allEntries[i].Path == msg.path {
+				ct.allEntries[i].Size = msg.size
+				ct.allEntries[i].Sized = true
+				break
+			}
+		}
+	} else {
+		filtered := make([]Entry, 0, len(ct.allEntries))
+		for _, e := range ct.allEntries {
+			if e.Path != msg.path {
+				filtered = append(filtered, e)
+			}
+		}
+		ct.allEntries = filtered
+		delete(ct.selected, msg.path)
+	}
+
+	sortEntries(ct.allEntries, sortSizeDesc)
+	m.applyFilterForTab(tabCaches)
+
+	if cursorPath != "" {
+		for i, e := range ct.entries {
+			if e.Path == cursorPath {
+				ct.cursor = i
+				break
+			}
+		}
+	}
+	if ct.cursor >= len(ct.entries) && len(ct.entries) > 0 {
+		ct.cursor = len(ct.entries) - 1
+	}
+	if len(ct.entries) == 0 {
+		ct.cursor = 0
+	}
+	if m.activeTab == tabCaches {
+		m.clampOffset()
 	}
 }
 

--- a/model.go
+++ b/model.go
@@ -538,6 +538,13 @@ func (m model) entryDisplayName(e Entry) string {
 	if m.activeTab == tabHistory && e.Path != "" {
 		name = e.Path
 	}
+	if m.activeTab == tabCaches && e.Path != "" {
+		if e.Path == dockerEntryPath {
+			name = e.Name
+		} else {
+			name = e.Name + " · " + e.Path
+		}
+	}
 	return name
 }
 

--- a/model_test.go
+++ b/model_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -825,5 +826,33 @@ func TestDockerPruneErrMsg(t *testing.T) {
 	if m2.mode != modeNormal || m2.confirmDocker || m2.errMsg == "" {
 		t.Errorf("mode=%v confirmDocker=%v errMsg=%q, want modeNormal+false with error",
 			m2.mode, m2.confirmDocker, m2.errMsg)
+	}
+}
+
+func TestEntryDisplayName_Caches(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	e := Entry{Name: "npm cache", Path: "/home/u/.npm/_cacache", IsDir: true}
+	if got := m.entryDisplayName(e); got != "npm cache · /home/u/.npm/_cacache" {
+		t.Errorf("entryDisplayName = %q", got)
+	}
+	d := Entry{Name: "Docker (system prune -a)", Path: dockerEntryPath}
+	if got := m.entryDisplayName(d); got != "Docker (system prune -a)" {
+		t.Errorf("docker entryDisplayName = %q", got)
+	}
+}
+
+func TestViewConfirm_Docker(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	m.mode = modeConfirm
+	m.confirmDocker = true
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{{Name: "Docker (system prune -a)", Path: dockerEntryPath, Sized: true}}
+	ct.entries = ct.allEntries
+
+	out := m.View()
+	if !strings.Contains(out, "docker system prune -a -f") {
+		t.Error("confirm dialog must show the exact prune command")
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -16,10 +17,10 @@ func newTestModel() model {
 
 func TestNameColWidth(t *testing.T) {
 	tests := []struct {
-		width    int
-		wantMin  int
-		wantMax  int
-		desc     string
+		width   int
+		wantMin int
+		wantMax int
+		desc    string
 	}{
 		{40, 10, 10, "very narrow terminal — clamped to min 10"},
 		{80, 10, 40, "normal terminal"},
@@ -721,5 +722,108 @@ func TestQuickScanDoneMsg(t *testing.T) {
 	}
 	if rm.path != "/tmp/test" {
 		t.Errorf("path = %q, want /tmp/test", rm.path)
+	}
+}
+
+func TestTabCachesID(t *testing.T) {
+	if tabBrowse != 0 || tabLargest != 1 || tabCaches != 2 || tabHistory != 3 {
+		t.Errorf("tab IDs = %d %d %d %d, want 0 1 2 3",
+			tabBrowse, tabLargest, tabCaches, tabHistory)
+	}
+	m := newTestModel()
+	if len(m.tabs) != 4 {
+		t.Errorf("len(tabs) = %d, want 4", len(m.tabs))
+	}
+}
+
+func TestCachesLoadedMsg(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	msg := cachesLoadedMsg{
+		entries: []Entry{
+			{Name: "npm cache", Path: "/home/u/.npm/_cacache", IsDir: true},
+			{Name: "Docker (system prune -a)", Path: dockerEntryPath},
+		},
+		pathGroups: map[string][]string{
+			"/home/u/.npm/_cacache": {"/home/u/.npm/_cacache"},
+		},
+	}
+	updated, cmd := m.Update(msg)
+	m2 := updated.(model)
+	ct := m2.tabs[tabCaches]
+	if len(ct.allEntries) != 2 || len(ct.entries) != 2 {
+		t.Fatalf("entries = %d/%d, want 2/2", len(ct.allEntries), len(ct.entries))
+	}
+	if m2.cachePathGroups == nil || len(m2.cachePathGroups["/home/u/.npm/_cacache"]) != 1 {
+		t.Errorf("cachePathGroups not stored: %+v", m2.cachePathGroups)
+	}
+	if cmd == nil {
+		t.Error("expected batch of size commands, got nil")
+	}
+}
+
+func TestCacheSizeMsg(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{
+		{Name: "small", Path: "/c/small", IsDir: true},
+		{Name: "big", Path: "/c/big", IsDir: true},
+	}
+	ct.entries = ct.allEntries
+
+	updated, _ := m.Update(cacheSizeMsg{path: "/c/big", size: 999, ok: true})
+	m2 := updated.(model)
+	ct2 := m2.tabs[tabCaches]
+	if ct2.entries[0].Path != "/c/big" || ct2.entries[0].Size != 999 || !ct2.entries[0].Sized {
+		t.Errorf("after size msg, first entry = %+v, want /c/big sized 999 first (size-desc)", ct2.entries[0])
+	}
+}
+
+func TestCacheSizeMsg_DropRow(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	ct := &m.tabs[tabCaches]
+	ct.allEntries = []Entry{
+		{Name: "npm cache", Path: "/c/npm", IsDir: true},
+		{Name: "Docker (system prune -a)", Path: dockerEntryPath},
+	}
+	ct.entries = ct.allEntries
+
+	updated, _ := m.Update(cacheSizeMsg{path: dockerEntryPath, ok: false})
+	m2 := updated.(model)
+	ct2 := m2.tabs[tabCaches]
+	if len(ct2.allEntries) != 1 || ct2.allEntries[0].Path != "/c/npm" {
+		t.Errorf("docker row not dropped: %+v", ct2.allEntries)
+	}
+}
+
+func TestDockerPruneDoneMsg(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabCaches
+	m.mode = modeConfirm
+	m.confirmDocker = true
+	updated, cmd := m.Update(dockerPruneDoneMsg{reclaimed: 4_200_000_000})
+	m2 := updated.(model)
+	if m2.mode != modeNormal || m2.confirmDocker {
+		t.Errorf("mode=%v confirmDocker=%v, want modeNormal+false", m2.mode, m2.confirmDocker)
+	}
+	if m2.cachesNote == "" {
+		t.Error("cachesNote empty, want reclaimed note")
+	}
+	if cmd == nil {
+		t.Error("expected dockerSizeCmd refresh, got nil")
+	}
+}
+
+func TestDockerPruneErrMsg(t *testing.T) {
+	m := newTestModel()
+	m.mode = modeConfirm
+	m.confirmDocker = true
+	updated, _ := m.Update(dockerPruneErrMsg{err: errors.New("daemon down")})
+	m2 := updated.(model)
+	if m2.mode != modeNormal || m2.confirmDocker || m2.errMsg == "" {
+		t.Errorf("mode=%v confirmDocker=%v errMsg=%q, want modeNormal+false with error",
+			m2.mode, m2.confirmDocker, m2.errMsg)
 	}
 }

--- a/view.go
+++ b/view.go
@@ -25,7 +25,7 @@ func gradientWave(text string, phase int) string {
 			b.WriteRune(r)
 			continue
 		}
-		idx := ((i + phase) % wl + wl) % wl
+		idx := ((i+phase)%wl + wl) % wl
 		b.WriteString(scanGradientStyles[idx].Render(string(r)))
 	}
 	return b.String()
@@ -194,6 +194,7 @@ func (m model) renderTabBar(contentWidth int) string {
 	tabs := []tabInfo{
 		{tabBrowse, "BROWSE"},
 		{tabLargest, "LARGEST"},
+		{tabCaches, "CACHES"},
 	}
 	if m.trashRegistry != nil && len(m.trashRegistry.Records) > 0 {
 		tabs = append(tabs, tabInfo{tabHistory, "HISTORY"})
@@ -209,6 +210,12 @@ func (m model) renderTabBar(contentWidth int) string {
 		// Show item count for HISTORY tab
 		if ti.id == tabHistory {
 			label += fmt.Sprintf(" (%d)", len(m.trashRegistry.Records))
+		}
+		// Show item count for CACHES tab once scanned
+		if ti.id == tabCaches {
+			if n := len(m.tabs[tabCaches].allEntries); n > 0 {
+				label += fmt.Sprintf(" (%d)", n)
+			}
 		}
 
 		if ti.id == m.activeTab {
@@ -337,6 +344,14 @@ func (m model) View() string {
 			"CREATED",
 			"UPDATED"))
 		b.WriteString(header)
+	case tabCaches:
+		header := headerStyle.Render(fmt.Sprintf("  %*s %9s %4s  %-*s  %-10s  %-10s",
+			barWidth, "",
+			"SIZE▼", "%",
+			nameWidth, "NAME · PATH",
+			"",
+			""))
+		b.WriteString(header)
 	case tabHistory:
 		header := headerStyle.Render(fmt.Sprintf("  %*s %9s %4s  %-*s  %-10s  %-10s",
 			barWidth, "",
@@ -431,6 +446,9 @@ func (m model) View() string {
 			if rel, err := filepath.Rel(m.path, e.Path); err == nil {
 				displayName = rel
 			}
+		}
+		if m.activeTab == tabCaches && e.Path != "" && e.Path != dockerEntryPath {
+			displayName = e.Name + " · " + e.Path
 		}
 
 		var row string
@@ -585,7 +603,9 @@ func (m model) View() string {
 			}
 		}
 		var confirmText string
-		if m.activeTab == tabHistory {
+		if m.confirmDocker {
+			confirmText = "  Run docker system prune -a -f? Removes ALL unused images, stopped containers, networks and build cache. Cannot be restored. [y/n]"
+		} else if m.activeTab == tabHistory {
 			confirmText = fmt.Sprintf("  Purge %d items (%s) permanently? [y/n]", count, formatSize(totalSize))
 		} else if m.deleteType == deleteTrash {
 			confirmText = fmt.Sprintf("  Trash %d items (%s)? [y/n]", count, formatSize(totalSize))
@@ -682,6 +702,18 @@ func (m model) View() string {
 		if !m.readOnly && len(t.selected) > 0 {
 			status += fmt.Sprintf(" · %d selected · %s", len(t.selected), formatSize(totalSelected))
 		}
+		if m.activeTab == tabCaches {
+			var cachesTotal int64
+			for _, e := range t.entries {
+				if e.Sized && e.Path != dockerEntryPath {
+					cachesTotal += e.Size
+				}
+			}
+			status += " · caches total: " + formatSize(cachesTotal)
+			if m.cachesNote != "" {
+				status += " · " + m.cachesNote
+			}
+		}
 		// Mode indicators
 		if !m.showHidden {
 			status += " · hidden:off"
@@ -774,7 +806,7 @@ func (m model) viewHelp(b *strings.Builder, contentWidth int) string {
 		"    enter        enter directory (BROWSE tab)",
 		"    backspace    go to parent directory",
 		"    esc          go to parent directory",
-		"    shift-tab    switch tab (BROWSE / LARGEST / HISTORY)",
+		"    shift-tab    switch tab (BROWSE / LARGEST / CACHES / HISTORY)",
 	}
 	if !m.readOnly {
 		lines = append(lines,
@@ -791,6 +823,11 @@ func (m model) viewHelp(b *strings.Builder, contentWidth int) string {
 			"    r            restore selected items to original location",
 			"    d            permanently delete selected items from trash",
 			"    s            toggle select",
+			"",
+			"  CACHES TAB",
+			"    d            clear selected caches (trash or permanent, tab to toggle)",
+			"    d on Docker  run docker system prune -a -f (always confirms)",
+			"    s            toggle select (Docker row is not selectable)",
 		)
 	}
 	lines = append(lines,

--- a/view_test.go
+++ b/view_test.go
@@ -211,3 +211,24 @@ func TestHeaderLabels(t *testing.T) {
 		t.Error("updatedHeaderLabel(sortUpdatedDesc) should include arrow")
 	}
 }
+
+func TestRenderTabBar_CachesAlwaysVisible(t *testing.T) {
+	m := newTestModel()
+	m.trashRegistry = &TrashRegistry{}
+	bar := m.renderTabBar(100)
+	if !strings.Contains(bar, "CACHES") {
+		t.Errorf("tab bar %q must contain CACHES", bar)
+	}
+	if strings.Contains(bar, "HISTORY") {
+		t.Errorf("tab bar %q must not contain HISTORY when trash is empty", bar)
+	}
+}
+
+func TestRenderTabBar_CachesCount(t *testing.T) {
+	m := newTestModel()
+	m.tabs[tabCaches].allEntries = []Entry{{Name: "npm cache", Path: "/a"}, {Name: "pip cache", Path: "/b"}}
+	bar := m.renderTabBar(100)
+	if !strings.Contains(bar, "CACHES (2)") {
+		t.Errorf("tab bar %q must contain CACHES (2)", bar)
+	}
+}


### PR DESCRIPTION
## Summary

New **CACHES** tab (BROWSE / LARGEST / **CACHES** / HISTORY) that finds known, safe-to-clear application caches and lets you clean them from the TUI.

- **Curated registry** per platform (`caches_darwin.go` / `caches_linux.go` / `caches_windows.go`): dev tools (npm, yarn, pnpm, pip, go-build, cargo, Gradle, Homebrew, composer, Hugging Face, CocoaPods, Xcode DerivedData, JetBrains, VS Code), browsers (Chrome, Chromium, Firefox, Safari, Edge, Brave, Opera, Arc, Yandex), messengers (Telegram, WhatsApp, Slack, Discord) and popular apps (Spotify, Teams, Zoom). Only cache subdirectories — never profiles or user data.
- **Glob support** in registry paths (`filepath.Glob`) to find variable segments like Firefox profiles, Telegram containers and `account-*` dirs — scoped to known parent locations only.
- **Async sizes**: rows appear instantly, sizes compute in the background and re-sort as they arrive (same pattern as BROWSE dir sizing).
- **Deletion** reuses the existing flow: `s`/`S` select, `e` dry-run, `tab` toggles trash/permanent, `d` deletes; trashed caches land in HISTORY and are restorable. Multi-path caches (e.g. Slack `Cache` + `CacheStorage`) are deleted as a group.
- **Docker** is a special row cleaned via `docker system prune -a -f` with its own confirmation (always confirms, even with `-y`); shows reclaimable size from `docker system df` and refreshes after prune. Not selectable, never enters HISTORY.
- Read-only mode disables both deletion and prune.

## Testing

- TDD throughout: registry resolution/scan/size tests, docker df & prune output parsing (fixtures), model message handling, key flow tests (tab cycle, docker confirm, group deletion), view tests (tab bar, confirm text, display names).
- `go vet`, full suite green, builds verified for darwin/linux/windows.
- Manual smoke test of the live TUI (expect-driven): tab switch, async size fill, `NAME · PATH` rows, docker confirm dialog + cancel.

🤖 Generated with AI Agent: ai-agent-kolesa